### PR TITLE
feat(zapx): expose caller skip level as an option for consumer

### DIFF
--- a/backend/zapx/zapx.go
+++ b/backend/zapx/zapx.go
@@ -18,6 +18,7 @@ type Backend struct {
 	// Options.TimeLayout takes precedence over this.
 	TimeLayout string
 	AddSource  bool
+	CallerSkip int
 }
 
 // Interface satisfaction (compile-time assertions).
@@ -59,8 +60,12 @@ func (b Backend) New(o logstox.Options[ZapField]) logstox.Logger[ZapField] {
 	var base *zap.Logger
 	var opts []zap.Option
 	if b.AddSource || o.AddSource {
+		skip := b.CallerSkip
+		if skip == 0 {
+			skip = 1
+		}
 		// AddCallerSkip(2) to point at the user's callsite (skipping our wrapper method).
-		opts = append(opts, zap.AddCaller(), zap.AddCallerSkip(2))
+		opts = append(opts, zap.AddCaller(), zap.AddCallerSkip(skip))
 	}
 
 	if o.Writer != nil {

--- a/backend/zapx/zapx.go
+++ b/backend/zapx/zapx.go
@@ -18,6 +18,9 @@ type Backend struct {
 	// Options.TimeLayout takes precedence over this.
 	TimeLayout string
 	AddSource  bool
+	// CallerSkip controls the number of stack frames to skip when reporting the caller.
+	// If zero, defaults to 1, which typically points to the caller of the logger method.
+	// Increase this value if wrapping the logger in additional abstraction layers.
 	CallerSkip int
 }
 

--- a/backend/zapx/zapx.go
+++ b/backend/zapx/zapx.go
@@ -67,7 +67,7 @@ func (b Backend) New(o logstox.Options[ZapField]) logstox.Logger[ZapField] {
 		if skip == 0 {
 			skip = 1
 		}
-		// AddCallerSkip(2) to point at the user's callsite (skipping our wrapper method).
+		// AddCallerSkip to point at the user's callsite (skipping wrapper methods).
 		opts = append(opts, zap.AddCaller(), zap.AddCallerSkip(skip))
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Logging callsite reporting is now configurable, allowing adjustment of which stack frame is reported. Defaults were updated to report the direct caller by default for improved accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->